### PR TITLE
SAR-46, SAR-48, and SAR-49

### DIFF
--- a/src/main/java/tr/com/srdc/cda2fhir/conf/Config.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/conf/Config.java
@@ -70,6 +70,8 @@ public class Config {
 	private static boolean generateDafProfileMetadata = false;
 	
 	private static boolean addedZerosToDateTime = false;
+	
+	private static boolean isTransactionBundle = false;
 
 	private static final Logger logger = LoggerFactory.getLogger(Config.class);
 
@@ -112,6 +114,14 @@ public class Config {
 
 	public static boolean addedZerosToDateTime() {
 		return addedZerosToDateTime;
+	}
+	
+	public static boolean getIsTransactionBundle() {
+		return isTransactionBundle;
+	}
+	
+	public static void setIsTransactionBundle(boolean transactionBundle) {
+		isTransactionBundle = transactionBundle;
 	}
 
 }

--- a/src/main/java/tr/com/srdc/cda2fhir/pipeline_wrapper/Wrapper.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/pipeline_wrapper/Wrapper.java
@@ -3,6 +3,7 @@ package tr.com.srdc.cda2fhir.pipeline_wrapper;
 import java.io.FileInputStream;
 
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleType;
 import org.openhealthtools.mdht.uml.cda.consol.ConsolPackage;
 import org.openhealthtools.mdht.uml.cda.consol.ContinuityOfCareDocument;
 import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
@@ -24,8 +25,8 @@ public class Wrapper {
 			ContinuityOfCareDocument cda = (ContinuityOfCareDocument) CDAUtil.loadAs(fis,
 					ConsolPackage.eINSTANCE.getContinuityOfCareDocument());
 
-			CCDTransformerImpl ccdTransformer = new CCDTransformerImpl(IdGeneratorEnum.COUNTER);
-			Bundle bundle = ccdTransformer.transformDocument(cda);
+			CCDTransformerImpl ccdTransformer = new CCDTransformerImpl(IdGeneratorEnum.UUID);
+			Bundle bundle =  ccdTransformer.transformDocument(cda, BundleType.TRANSACTION, null, null, null);
 			FHIRUtil.printJSON(bundle, args[1]);
 		} else {
 			logger.error("Wrapper run without arguments");

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/CCDTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/CCDTransformerImpl.java
@@ -45,6 +45,7 @@ import org.openhealthtools.mdht.uml.cda.util.CDAUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import tr.com.srdc.cda2fhir.conf.Config;
 import tr.com.srdc.cda2fhir.transform.entry.IEntryResult;
 import tr.com.srdc.cda2fhir.transform.section.CDASectionTypeEnum;
 import tr.com.srdc.cda2fhir.transform.section.ICDASection;
@@ -209,6 +210,9 @@ public class CCDTransformerImpl implements ICDATransformer, Serializable {
 	public Bundle transformDocument(String filePath, BundleType bundleType, Map<String, String> resourceProfileMap,
 			String documentBody, Identifier assemblerDevice) throws Exception {
 		ContinuityOfCareDocument cda = getClinicalDocument(filePath);
+		if (bundleType.equals(BundleType.TRANSACTION)) {
+			Config.setIsTransactionBundle(true);
+		}
 		Bundle bundle = transformDocument(cda, true);
 		bundle.setType(bundleType);
 		if (assemblerDevice != null && !StringUtils.isEmpty(documentBody)) {
@@ -272,6 +276,9 @@ public class CCDTransformerImpl implements ICDATransformer, Serializable {
 	@Override
 	public Bundle transformDocument(ContinuityOfCareDocument cda, BundleType bundleType,
 			Map<String, String> resourceProfileMap, String documentBody, Identifier assemblerDevice) throws Exception {
+		if (bundleType.equals(BundleType.TRANSACTION)) {
+			Config.setIsTransactionBundle(true);
+		}
 		Bundle bundle = transformDocument(cda, true);
 		bundle.setType(bundleType);
 		if (assemblerDevice != null && !StringUtils.isEmpty(documentBody)) {

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -26,6 +26,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.eclipse.emf.common.util.EList;
@@ -2122,6 +2123,7 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 		IMedicationsInformation medsInfo = null;
 		CD cd = null;
 		List<II> orgIds = null;
+		Map<String, ManufacturedProduct> medDedupMap = bundleInfo.getMedicationDedupMap();
 
 		if (cdaManufacturedProduct.getManufacturedMaterial() != null
 				&& !cdaManufacturedProduct.getManufacturedMaterial().isSetNullFlavor()) {
@@ -2129,9 +2131,13 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 			cd = cdaManufacturedProduct.getManufacturedMaterial().getCode();
 
 			if (cd != null) {
-
-				medsInfo = bundleInfo.findResourceResult(cd);
-
+				if (medDedupMap.containsKey(cd.getCode()) && cd.getTranslations().size() < medDedupMap.get(cd.getCode()).getManufacturedMaterial().getCode().getTranslations().size()) {
+					cdaManufacturedProduct = medDedupMap.get(cd.getCode());
+					medsInfo = bundleInfo.findResourceResult(medDedupMap.get(cd.getCode()).getManufacturedMaterial().getCode());
+				} else {
+					medsInfo = bundleInfo.findResourceResult(cd);
+				}
+				medDedupMap.put(cd.getCode(), cdaManufacturedProduct);
 				// manufacturedMaterial.code -> code
 				fhirMedication.setCode(dtt.tCD2CodeableConcept(
 						cdaManufacturedProduct.getManufacturedMaterial().getCode(), bundleInfo.getIdedAnnotations()));
@@ -2152,9 +2158,6 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 		if (cdaManufacturedProduct.getManufacturerOrganization() != null
 				&& !cdaManufacturedProduct.getManufacturerOrganization().isSetNullFlavor()) {
 
-			if (cdaManufacturedProduct.getManufacturerOrganization().getIds() != null) {
-				orgIds = cdaManufacturedProduct.getManufacturerOrganization().getIds();
-			}
 			IEntryResult orgResult = tOrganization2Organization(cdaManufacturedProduct.getManufacturerOrganization(),
 					bundleInfo);
 
@@ -2170,22 +2173,16 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 
 		}
 
-		if (medsInfo != null && medsInfo.containsMedication(cd, orgIds)) {
+		if (medsInfo != null) {
 			Medication previousMedication = medsInfo.getMedication(cd, orgIds);
 
 			if (previousMedication != null) {
 				result.addExistingResource(previousMedication);
 			}
 		} else {
-			if (medsInfo == null && cd != null) {
+			if (cd != null) {
 				medsInfo = new MedicationsInformation(fhirMedication, cd, orgIds);
 				result.putCDResource(cd, medsInfo);
-			} else if (!medsInfo.containsMedication(cd, orgIds) && cd != null) {
-				if (orgIds != null) {
-					medsInfo.putMedication(fhirMedication, cd, orgIds);
-				} else {
-					medsInfo.putMedication(fhirMedication, cd);
-				}
 			}
 			result.addResource(fhirMedication);
 		}

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ResourceTransformerImpl.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.eclipse.emf.common.util.EList;
@@ -2883,7 +2884,8 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 	public IEntryResult tOrganization2Organization(org.openhealthtools.mdht.uml.cda.Organization cdaOrganization,
 			IBundleInfo bundleInfo) {
 		EntryResult result = new EntryResult();
-
+		Set<String> orgNameSet = bundleInfo.getOrganizationnDedupMap();
+		boolean inSet = false;
 		if (cdaOrganization == null || cdaOrganization.isSetNullFlavor()) {
 			return result;
 		}
@@ -2931,6 +2933,10 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 					} else {
 						fhirOrganization.addAlias(name.getText());
 					}
+					if (orgNameSet.contains(name.getText()))
+						inSet = true;
+
+					orgNameSet.add(name.getText());
 				}
 			}
 
@@ -2958,8 +2964,8 @@ public class ResourceTransformerImpl implements IResourceTransformer, Serializab
 		if (!fhirOrganization.hasName() && !fhirOrganization.hasIdentifier()) {
 			return result;
 		}
-
-		result.addResource(fhirOrganization);
+		if (!inSet)
+			result.addResource(fhirOrganization);
 		return result;
 
 	}

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/ValueSetsTransformerImpl.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/ValueSetsTransformerImpl.java
@@ -55,6 +55,8 @@ import org.openhealthtools.mdht.uml.hl7.vocab.NullFlavor;
 import org.openhealthtools.mdht.uml.hl7.vocab.PostalAddressUse;
 import org.openhealthtools.mdht.uml.hl7.vocab.TelecommunicationAddressUse;
 
+import tr.com.srdc.cda2fhir.conf.Config;
+
 
 public class ValueSetsTransformerImpl implements IValueSetsTransformer, Serializable {
 
@@ -412,7 +414,7 @@ public class ValueSetsTransformerImpl implements IValueSetsTransformer, Serializ
 		if (cdaObservationInterpretationCode == null)
 			return null;
 		Coding obsIntCode = new Coding();
-		obsIntCode.setSystem("http://hl7.org/fhir/v2/0078");
+		obsIntCode.setSystem("http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation");
 
 		String code = null, display = null;
 
@@ -466,7 +468,11 @@ public class ValueSetsTransformerImpl implements IValueSetsTransformer, Serializ
 			}
 		}
 		obsIntCode.setCode(code);
-		obsIntCode.setDisplay(display);
+		
+		if (Config.getIsTransactionBundle() == false) {
+			obsIntCode.setDisplay(display);
+		}
+		
 		return new CodeableConcept().addCoding(obsIntCode);
 	}
 

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/util/IBundleInfo.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/util/IBundleInfo.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.openhealthtools.mdht.uml.cda.ManufacturedProduct;
 import org.openhealthtools.mdht.uml.hl7.datatypes.CD;
 import org.openhealthtools.mdht.uml.hl7.datatypes.II;
 
@@ -21,6 +22,8 @@ public interface IBundleInfo {
 	IResourceTransformer getResourceTransformer();
 
 	Map<String, String> getIdedAnnotations();
+	
+	Map<String, ManufacturedProduct> getMedicationDedupMap();
 
 	Reference getReferenceByIdentifier(String fhirType, Identifier identifier);
 

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/util/IBundleInfo.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/util/IBundleInfo.java
@@ -2,6 +2,7 @@ package tr.com.srdc.cda2fhir.transform.util;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Reference;
@@ -24,6 +25,8 @@ public interface IBundleInfo {
 	Map<String, String> getIdedAnnotations();
 	
 	Map<String, ManufacturedProduct> getMedicationDedupMap();
+	
+	Set<String> getOrganizationnDedupMap();
 
 	Reference getReferenceByIdentifier(String fhirType, Identifier identifier);
 

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/util/impl/BundleInfo.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/util/impl/BundleInfo.java
@@ -1,8 +1,10 @@
 package tr.com.srdc.cda2fhir.transform.util.impl;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Reference;
@@ -29,6 +31,7 @@ public class BundleInfo implements IBundleInfo {
 	private CDAIIResourceMaps<IBaseResource> resourceMaps = new CDAIIResourceMaps<IBaseResource>();
 	private CDACDMap<IMedicationsInformation> cdMap = new CDACDMap<IMedicationsInformation>();
 	private Map<String,ManufacturedProduct> medicationDedupMap = new HashMap<String,ManufacturedProduct>();
+	private Set<String> organizationDedupMap = new HashSet<String>();
 
 	public BundleInfo(IResourceTransformer resourceTransformer) {
 		this.resourceTransformer = resourceTransformer;
@@ -37,6 +40,11 @@ public class BundleInfo implements IBundleInfo {
 	@Override
 	public Map<String, ManufacturedProduct> getMedicationDedupMap() {
 		return medicationDedupMap;
+	}
+	
+	@Override
+	public Set<String> getOrganizationnDedupMap() {
+		return organizationDedupMap;
 	}
 	
 	@Override

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/util/impl/BundleInfo.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/util/impl/BundleInfo.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.openhealthtools.mdht.uml.cda.ManufacturedProduct;
 import org.openhealthtools.mdht.uml.hl7.datatypes.CD;
 import org.openhealthtools.mdht.uml.hl7.datatypes.II;
 
@@ -27,11 +28,17 @@ public class BundleInfo implements IBundleInfo {
 	private CDAIIMap<IEntityInfo> entities = new CDAIIMap<IEntityInfo>();
 	private CDAIIResourceMaps<IBaseResource> resourceMaps = new CDAIIResourceMaps<IBaseResource>();
 	private CDACDMap<IMedicationsInformation> cdMap = new CDACDMap<IMedicationsInformation>();
+	private Map<String,ManufacturedProduct> medicationDedupMap = new HashMap<String,ManufacturedProduct>();
 
 	public BundleInfo(IResourceTransformer resourceTransformer) {
 		this.resourceTransformer = resourceTransformer;
 	}
 
+	@Override
+	public Map<String, ManufacturedProduct> getMedicationDedupMap() {
+		return medicationDedupMap;
+	}
+	
 	@Override
 	public IResourceTransformer getResourceTransformer() {
 		return resourceTransformer;
@@ -122,5 +129,4 @@ public class BundleInfo implements IBundleInfo {
 	public CDACDMap<IMedicationsInformation> getCDMap() {
 		return cdMap;
 	}
-
 }

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/util/impl/BundleRequest.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/util/impl/BundleRequest.java
@@ -138,6 +138,25 @@ public class BundleRequest {
 					}
 				}
 			}
+			if (bundleEntry.getResource().getResourceType().name() == "Organization") {
+				Property orgNames = bundleEntry.getResource().getChildByName("name");
+				if (orgNames != null) {
+					List<Base> nameList = orgNames.getValues();
+					for(Base entry: nameList) {
+						String name = entry.primitiveValue();
+						if(name != null && !name.isEmpty()) {
+							if (ifNotExistString != "") {
+								ifNotExistString = ifNotExistString + ",";
+							} else {
+								ifNotExistString = "identifier=";
+							}
+							ifNotExistString = ifNotExistString + name.replaceAll(" ", "").toLowerCase();
+						}
+						
+					}
+				}
+			}
+			
 
 			// if it's a practitioner role, de-duplicate by reference ids.
 			if (bundleEntry.getResource().getResourceType().name() == "PractitionerRole") {

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/util/impl/LocalBundleInfo.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/util/impl/LocalBundleInfo.java
@@ -2,6 +2,7 @@ package tr.com.srdc.cda2fhir.transform.util.impl;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Reference;
@@ -135,7 +136,11 @@ public class LocalBundleInfo implements IBundleInfo {
 
 	@Override
 	public Map<String, ManufacturedProduct> getMedicationDedupMap() {
-		// TODO Auto-generated method stub
 		return bundleInfo.getMedicationDedupMap();
+	}
+
+	@Override
+	public Set<String> getOrganizationnDedupMap() {
+		return bundleInfo.getOrganizationnDedupMap();
 	}
 }

--- a/src/main/java/tr/com/srdc/cda2fhir/transform/util/impl/LocalBundleInfo.java
+++ b/src/main/java/tr/com/srdc/cda2fhir/transform/util/impl/LocalBundleInfo.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.openhealthtools.mdht.uml.cda.ManufacturedProduct;
 import org.openhealthtools.mdht.uml.hl7.datatypes.CD;
 import org.openhealthtools.mdht.uml.hl7.datatypes.II;
 
@@ -132,4 +133,9 @@ public class LocalBundleInfo implements IBundleInfo {
 		return cdMap;
 	}
 
+	@Override
+	public Map<String, ManufacturedProduct> getMedicationDedupMap() {
+		// TODO Auto-generated method stub
+		return bundleInfo.getMedicationDedupMap();
+	}
 }

--- a/src/test/java/tr/com/srdc/cda2fhir/CCDTransformerTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/CCDTransformerTest.java
@@ -218,7 +218,7 @@ public class CCDTransformerTest {
 		verifySection(bundle, "RESULTS", DiagnosticReport.class, 2, 2);
 		verifySection(bundle, "FUNCTIONAL STATUS", Observation.class, 20, 2);
 		verifySection(bundle, "FAMILY HISTORY", FamilyMemberHistory.class, 1, 1);
-		verifySection(bundle, "MEDICAL EQUIPMENT", Resource.class, 81, 4);
+		verifySection(bundle, "MEDICAL EQUIPMENT", Resource.class, 79, 4);
 
 		// Spot checks
 		BundleUtil util = new BundleUtil(bundle);

--- a/src/test/java/tr/com/srdc/cda2fhir/CCDTransformerTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/CCDTransformerTest.java
@@ -218,7 +218,7 @@ public class CCDTransformerTest {
 		verifySection(bundle, "RESULTS", DiagnosticReport.class, 2, 2);
 		verifySection(bundle, "FUNCTIONAL STATUS", Observation.class, 20, 2);
 		verifySection(bundle, "FAMILY HISTORY", FamilyMemberHistory.class, 1, 1);
-		verifySection(bundle, "MEDICAL EQUIPMENT", Resource.class, 79, 4);
+		verifySection(bundle, "MEDICAL EQUIPMENT", Resource.class, 72, 4);
 
 		// Spot checks
 		BundleUtil util = new BundleUtil(bundle);

--- a/src/test/java/tr/com/srdc/cda2fhir/DeduplicationTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/DeduplicationTest.java
@@ -196,7 +196,7 @@ public class DeduplicationTest {
 
 		Bundle resultBundle = runMedidicationDeduplicationTest(medActs, 2, false, null);
 
-		BundleUtil.findResources(resultBundle, Organization.class, 2);
+		BundleUtil.findResources(resultBundle, Organization.class, 1);
 
 	}
 
@@ -319,7 +319,7 @@ public class DeduplicationTest {
 		Bundle resultBundle = runMedidicationDeduplicationTest(medActs, 3, true,
 				"src/test/resources/output/hello-world.json");
 
-		BundleUtil.findResources(resultBundle, Organization.class, 5);
+		BundleUtil.findResources(resultBundle, Organization.class, 1);
 
 	}
 
@@ -358,7 +358,7 @@ public class DeduplicationTest {
 
 		Bundle resultBundle = runMedidicationDeduplicationTest(medActs, 1, false, null);
 
-		BundleUtil.findResources(resultBundle, Organization.class, 2);
+		BundleUtil.findResources(resultBundle, Organization.class, 1);
 
 	}
 
@@ -549,7 +549,7 @@ public class DeduplicationTest {
 
 		Bundle resultBundle = ccdTransformer.transformDocument(clinicalDoc);
 
-		BundleUtil.findResources(resultBundle, Organization.class, 2);
+		BundleUtil.findResources(resultBundle, Organization.class, 1);
 
 	}
 
@@ -746,7 +746,7 @@ public class DeduplicationTest {
 
 		Bundle resultBundle = ccdTransformer.transformDocument(document);
 
-		BundleUtil.findResources(resultBundle, Organization.class, 5);
+		BundleUtil.findResources(resultBundle, Organization.class, 3);
 
 	}
 

--- a/src/test/java/tr/com/srdc/cda2fhir/DeduplicationTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/DeduplicationTest.java
@@ -286,7 +286,7 @@ public class DeduplicationTest {
 
 		medActs.add(medActGenerator3.generate(factories));
 
-		Bundle resultBundle = runMedidicationDeduplicationTest(medActs, 3, true, "src/test/resources/output/wtf.json");
+		Bundle resultBundle = runMedidicationDeduplicationTest(medActs, 2, true, "src/test/resources/output/wtf.json");
 
 		BundleUtil.findResources(resultBundle, Organization.class, 1);
 
@@ -356,7 +356,7 @@ public class DeduplicationTest {
 
 		medActs.add(medActGenerator2.generate(factories));
 
-		Bundle resultBundle = runMedidicationDeduplicationTest(medActs, 2, false, null);
+		Bundle resultBundle = runMedidicationDeduplicationTest(medActs, 1, false, null);
 
 		BundleUtil.findResources(resultBundle, Organization.class, 2);
 

--- a/src/test/java/tr/com/srdc/cda2fhir/IntegrationTest.java
+++ b/src/test/java/tr/com/srdc/cda2fhir/IntegrationTest.java
@@ -145,7 +145,7 @@ public class IntegrationTest {
 
 		// 3 organizations don't have identifiers.
 		Bundle organizationResults = (Bundle) client.search().forResource(Organization.class).prettyPrint().execute();
-		Assert.assertEquals(9, organizationResults.getTotal());
+		Assert.assertEquals(4, organizationResults.getTotal());
 
 		// Non de-duplicating resources below.
 		Bundle documentReferenceResults = (Bundle) client.search().forResource(DocumentReference.class).prettyPrint()

--- a/src/test/resources/C-CDA_R2-1_CCD.xml
+++ b/src/test/resources/C-CDA_R2-1_CCD.xml
@@ -1330,7 +1330,7 @@
 							<!-- ** Immunization Activity (V3) ** -->
 							<templateId root="2.16.840.1.113883.10.20.22.4.52" extension="2015-08-01"/>
 							<templateId root="2.16.840.1.113883.10.20.22.4.52"/>
-							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92"/>
+							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f93"/>
 							<text>
 								<reference value="#immun2"/>
 							</text>
@@ -1407,7 +1407,7 @@
 							<!-- ** Immunization Activity (V3) ** -->
 							<templateId root="2.16.840.1.113883.10.20.22.4.52" extension="2015-08-01"/>
 							<templateId root="2.16.840.1.113883.10.20.22.4.52"/>
-							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92"/>
+							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f94"/>
 							<text>
 								<reference value="#immun3"/>
 							</text>
@@ -1491,7 +1491,7 @@
 							<!-- ** Immunization Activity (V3) ** -->
 							<templateId root="2.16.840.1.113883.10.20.22.4.52" extension="2015-08-01"/>
 							<templateId root="2.16.840.1.113883.10.20.22.4.52"/>
-							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92"/>
+							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f95"/>
 							<text>
 								<reference value="#immun4"/>
 							</text>

--- a/src/test/resources/C-CDA_R2-1_CCD2.xml
+++ b/src/test/resources/C-CDA_R2-1_CCD2.xml
@@ -1332,7 +1332,7 @@
 							<!-- ** Immunization Activity (V3) ** -->
 							<templateId root="2.16.840.1.113883.10.20.22.4.52" extension="2015-08-01"/>
 							<templateId root="2.16.840.1.113883.10.20.22.4.52"/>
-							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92"/>
+							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f93"/>
 							<text>
 								<reference value="#immun2"/>
 							</text>
@@ -1409,7 +1409,7 @@
 							<!-- ** Immunization Activity (V3) ** -->
 							<templateId root="2.16.840.1.113883.10.20.22.4.52" extension="2015-08-01"/>
 							<templateId root="2.16.840.1.113883.10.20.22.4.52"/>
-							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92"/>
+							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f94"/>
 							<text>
 								<reference value="#immun3"/>
 							</text>
@@ -1493,7 +1493,7 @@
 							<!-- ** Immunization Activity (V3) ** -->
 							<templateId root="2.16.840.1.113883.10.20.22.4.52" extension="2015-08-01"/>
 							<templateId root="2.16.840.1.113883.10.20.22.4.52"/>
-							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92"/>
+							<id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f95"/>
 							<text>
 								<reference value="#immun4"/>
 							</text>


### PR DESCRIPTION
#### What does this PR do?
- Implements a temporary fix for mapped Medication with the same `ManufacturedMaterial` code for `C-CDA_R2-1_CCD.xml` and `C-CDA_R2-1_CCD2.xml`
- Instead of creating a new medications for a medications that have the same `ManufacturedMaterial` code, we only output one.
- It also fixes the error thrown by the server: `unable to access result.resource.interpretation.coding[0].display`
- It also consolidates Organizations based on name into one
#### Related JIRA tickets:
- [SAR-46](https://jira.amida.com/browse/SAR-46)
- [SAR-48](https://jira.amida.com/browse/SAR-48)
- [SAR-49](https://jira.amida.com/browse/SAR-40)

#### How should this be manually tested?
Create **transactional** bundles for `C-CDA_R2-1_CCD.xml` and `C-CDA_R2-1_CCD2.xml`
Ensure there is only one organization with the name `Medication Factory Inc.` in the bundle
Run jpa server
Post bundles to jpa server using postman to `http://localhost:8080/hapi-fhir-jpaserver/fhir`
Ensure that all resources are created and you get a 200 response back
